### PR TITLE
Fixed name clash. Corrected namespace name and output name

### DIFF
--- a/Parquet/Parquet.csproj
+++ b/Parquet/Parquet.csproj
@@ -1,28 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
-    <PropertyGroup>
-        <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
-        <TargetFrameworkVersion></TargetFrameworkVersion>
-        <TargetFramework>netstandard2.0</TargetFramework>
-		<DebugWith>Editor CE</DebugWith>
-		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
-		<AssemblyVersion>$(GitVersion)</AssemblyVersion>
-    </PropertyGroup>
-    
+  <PropertyGroup>
+    <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
+    <TargetFrameworkVersion></TargetFrameworkVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetName>OpenTap.Plugins.Parquet</TargetName>
+    <DebugWith>Editor CE</DebugWith>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AssemblyVersion>$(GitVersion)</AssemblyVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <PropertyGroup>
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
     <CreateOpenTapPackage>false</CreateOpenTapPackage>
   </PropertyGroup>
-  
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <CreateOpenTapPackage>true</CreateOpenTapPackage>
-    </PropertyGroup>
-    <ItemGroup Condition="'$(DebugWith)' == 'Editor CE' and '$(Configuration)' == 'Debug'">
-	    <OpenTapPackageReference Include="Editor CE" version="beta" />
-	    <OpenTapPackageReference Include="Demonstration" version="beta" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="OpenTAP" Version="9.22.0-rc.1" />
-        <PackageReference Include="Parquet.Net" Version="3.3.9" />
-    </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <CreateOpenTapPackage>true</CreateOpenTapPackage>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(DebugWith)' == 'Editor CE' and '$(Configuration)' == 'Debug'">
+    <OpenTapPackageReference Include="Editor CE" version="beta" />
+    <OpenTapPackageReference Include="Demonstration" version="beta" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTAP" Version="9.22.0-rc.1" />
+    <PackageReference Include="Parquet.Net" Version="3.3.9" />
+  </ItemGroup>
 </Project>

--- a/Parquet/ResultListener/ParquetFile.cs
+++ b/Parquet/ResultListener/ParquetFile.cs
@@ -1,15 +1,12 @@
-﻿using OpenTap;
-using Parquet;
+﻿using Parquet;
 using Parquet.Data;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Parquet.ResultListener
+namespace OpenTap.Plugins.Parquet
 {
     internal sealed class ParquetFile : IDisposable
     {

--- a/Parquet/ResultListener/ParquetResultListener.cs
+++ b/Parquet/ResultListener/ParquetResultListener.cs
@@ -1,11 +1,9 @@
-﻿using OpenTap;
-using Parquet.Data;
+﻿using Parquet.Data;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 
-namespace Parquet.ResultListener
+namespace OpenTap.Plugins.Parquet
 {
     [Display("Parquet Result Listener")]
     public sealed class ParquetResultListener : OpenTap.ResultListener

--- a/Parquet/ResultListener/SchemaBuilder.cs
+++ b/Parquet/ResultListener/SchemaBuilder.cs
@@ -1,12 +1,9 @@
-﻿using OpenTap;
-using Parquet.Data;
+﻿using Parquet.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Thrift.Protocol;
 
-namespace Parquet.ResultListener
+namespace OpenTap.Plugins.Parquet
 {
     internal enum ColumnType
     {

--- a/Parquet/ResultListener/TypeExtensions.cs
+++ b/Parquet/ResultListener/TypeExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Parquet.ResultListener
+namespace OpenTap.Plugins.Parquet
 {
     internal static class TypeExtensions
     {

--- a/Parquet/package.xml
+++ b/Parquet/package.xml
@@ -16,7 +16,7 @@ $(GitVersion) - Gets the version from Git in the recommended format Major.Minor.
 	<Prerequisites>None</Prerequisites>
 	<Owner>OpenTAP</Owner>
 	<Files>
-		<File Path="Packages/Parquet/Parquet.dll" SourcePath="Parquet.dll">
+		<File Path="Packages/Parquet/OpenTap.Plugins.Parquet.dll" SourcePath="OpenTap.Plugins.Parquet.dll">
 			<SetAssemblyInfo Attributes="Version"/>
 		</File>
 	</Files>


### PR DESCRIPTION
A couple of comments:
- why don't you update the `Parquet.NET` to `3.10.0`?
- do you need the dependency on the `Demonstration` plugin?