### PR TITLE
Minor updates

### DIFF
--- a/Parquet/Parquet.csproj
+++ b/Parquet/Parquet.csproj
@@ -24,7 +24,7 @@
     <OpenTapPackageReference Include="Demonstration" version="beta" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTAP" Version="9.22.0-rc.1" />
+    <PackageReference Include="OpenTAP" Version="9.22.2" />
     <PackageReference Include="Parquet.Net" Version="3.10.0" />
   </ItemGroup>
 </Project>

--- a/Parquet/ResultListener/ParquetResultListener.cs
+++ b/Parquet/ResultListener/ParquetResultListener.cs
@@ -17,7 +17,7 @@ namespace OpenTap.Plugins.Parquet
 
         public ParquetResultListener()
         {
-            Name = nameof(ParquetResultListener);
+            Name = "Parquet";
         }
 
         public override void Open()


### PR DESCRIPTION
Updated the opentap reference to 9.22
Rename parquet result listener to "Parquet" to be similar to csv, sqlite, html etc.