### PR TITLE
Upgrade and pin GitHub Actions to latest SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@main
+        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a # v1.1
 
   ##############
   ### BUILD   ##
@@ -37,7 +37,7 @@ jobs:
       ShortVersion: ${{needs.GetVersion.outputs.ShortVersion}}
       LongVersion: ${{needs.GetVersion.outputs.LongVersion}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Fix tags
@@ -50,14 +50,14 @@ jobs:
       - name: Pack
         run: dotnet pack -c Release ./Parquet.Core/Parquet.Core.csproj -o .
       - name: Upload OpenTAP package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: tap-package
           retention-days: 7
           path: |
             Parquet/bin/Release/net9.0/*.TapPackage
       - name: Upload NuGet package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nuget-package
           retention-days: 7
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         run: dotnet test -c Release
 
@@ -90,12 +90,12 @@ jobs:
         - UnitTests
       steps:
         - name: Download TapPackage Artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           with:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@v1.0
+          uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 # v1.0
           with:
             version: 9.29.1
             packages: "Repository Client"
@@ -111,7 +111,7 @@ jobs:
       - UnitTests
     steps:
       - name: Download NuGet Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget-package
       - name: Publish NuGet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@4b5b2a31dcea4c48d792754cd8141f01792ede28 #fix/pin-action-shas (pending v1.2)
+        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a #v1.1
 
   ##############
   ### BUILD   ##
@@ -95,7 +95,7 @@ jobs:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@2e83d3a5e985a85061d009ac858817c422ee014f #fix/upgrade-node-to-node24 (pending v1.1)
+          uses: opentap/setup-opentap@6eee68cf35f2e861f93d21029bbe7af4c427b9bd #main (pending v1.1)
           with:
             version: 9.29.1
             packages: "Repository Client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@e785d4cb7ba83c1ca846e20e0925e8067c6fb337 #fix/pin-action-shas (pending v1.2)
+        uses: opentap/get-gitversion@dd1b64ee828bcd62c3b53b5aabca464fe41123fa #fix/pin-action-shas (pending v1.2)
 
   ##############
   ### BUILD   ##
@@ -95,7 +95,7 @@ jobs:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@c60c3386267d6c8c39d5ad8bd76a219c20f12f33 #fix/upgrade-node-to-node24 (pending v1.1)
+          uses: opentap/setup-opentap@2e83d3a5e985a85061d009ac858817c422ee014f #fix/upgrade-node-to-node24 (pending v1.1)
           with:
             version: 9.29.1
             packages: "Repository Client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a #v1.1
+        uses: opentap/get-gitversion@e785d4cb7ba83c1ca846e20e0925e8067c6fb337 #fix/pin-action-shas (pending v1.2)
 
   ##############
   ### BUILD   ##
@@ -95,7 +95,7 @@ jobs:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 #v1.0
+          uses: opentap/setup-opentap@c60c3386267d6c8c39d5ad8bd76a219c20f12f33 #fix/upgrade-node-to-node24 (pending v1.1)
           with:
             version: 9.29.1
             packages: "Repository Client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@dd1b64ee828bcd62c3b53b5aabca464fe41123fa #fix/pin-action-shas (pending v1.2)
+        uses: opentap/get-gitversion@4b5b2a31dcea4c48d792754cd8141f01792ede28 #fix/pin-action-shas (pending v1.2)
 
   ##############
   ### BUILD   ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a # v1.1
+        uses: opentap/get-gitversion@main
 
   ##############
   ### BUILD   ##
@@ -95,7 +95,7 @@ jobs:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 # v1.0
+          uses: opentap/setup-opentap@main
           with:
             version: 9.29.1
             packages: "Repository Client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@main
+        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a #v1.1
 
   ##############
   ### BUILD   ##
@@ -95,7 +95,7 @@ jobs:
             name: tap-package
             path: .
         - name: Setup OpenTAP
-          uses: opentap/setup-opentap@main
+          uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 #v1.0
           with:
             version: 9.29.1
             packages: "Repository Client"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@1ecd47ca05a3124a5f2479e0bfd0665f93359b2a #v1.1
+        uses: opentap/get-gitversion@38a48d0e35cb69a16e68312183507a704cdc35be #fix/pin-action-shas (pending v1.2)
 
   ##############
   ### BUILD   ##

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: GitVersion
         id: gitversion
-        uses: opentap/get-gitversion@38a48d0e35cb69a16e68312183507a704cdc35be #fix/pin-action-shas (pending v1.2)
+        uses: opentap/get-gitversion@d1353d4355f2c12e09bb7886ccc9aa7d18243ebc #main (pending v1.2)
 
   ##############
   ### BUILD   ##

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,7 +17,7 @@ jobs:
     name: pr-version-comment
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # This action needs the entire history of the repository to calculate the version
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full 40-character commit SHAs to reduce supply-chain risk. Both third-party and opentap-owned actions are pinned.

## Changes

All floating tags (e.g. `@v4`, `@main`) replaced with pinned SHAs. opentap-owned actions are pinned to main branch commits pending tagged releases:

- `opentap/get-gitversion` → `d1353d4355f2c12e09bb7886ccc9aa7d18243ebc` *(main, pending v1.2)*
- `opentap/setup-opentap` → `6eee68cf35f2e861f93d21029bbe7af4c427b9bd` *(main, pending v1.1)*

Where `opentap/get-gitversion` is used, a `persist-credentials: false` flag has been added to the preceding `actions/checkout` step to avoid a duplicate Authorization header conflict introduced in `actions/checkout@v6`.

## Merge order

This PR depends on upstream opentap action releases. Recommended order:
1. ~~Merge and tag `opentap/setup-opentap#19` as `v1.1`~~ ✅ Merged
2. ~~Merge and tag `opentap/get-gitversion#8` as `v1.2`~~ ✅ Merged — tag pending
3. Update the SHAs in this PR to the released tags once `v1.1` and `v1.2` are cut
4. Merge this PR